### PR TITLE
remove 'spp.' epithet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,9 @@ Authors@R: c(
             person("Scott", "Chamberlain", role ="aut", 
                    comment = c(ORCID="0000-0003-1444-9135")),
             person("Noam", "Ross", , "ross@ecohealthalliance.org", role ="ctb",
-                   comment = c(ORCID = "0000-0002-2136-0000"))
+                   comment = c(ORCID = "0000-0002-2136-0000")),
+            person("Mattia", "Ghilardi", role ="ctb",
+                   comment = c(ORCID = "0000-0001-9592-7252"))
             )
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # taxadb 0.2.2
 
+* `clean_names` now also removes the "spp." epithet
+
 # taxadb 0.2.1
 
 * substantial speed improvements to all `filter_*` and `get_*` functions

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -66,9 +66,10 @@ set_space_delim <- function(x)
   stringi::stri_trim()
 
 drop_sp. <- function(x){
-  # drop: cladophora sp2, cladophora sp., cladophora ssp.
-  stringi::stri_replace_all_regex(x, "\\ssp[s\\d\\.]?$", "")
-
+  # drop: cladophora sp2, cladophora sp., cladophora sps, cladophora sp
+  x <- stringi::stri_replace_all_regex(x, "\\ssp[s\\d\\.]?$", "")
+  # drop: cladophora spp, cladophora spp.
+  stringi::stri_replace_all_regex(x, "\\sspp[\\.]?$", "")
 }
 binomial_names <- function(x){
   s <-

--- a/tests/testthat/test-clean_names.R
+++ b/tests/testthat/test-clean_names.R
@@ -8,6 +8,9 @@ test_that("set_space_delim", {
 test_that("drop_sp.", {
   x <- drop_sp.("Poa sp.")
   expect_identical(x, "Poa")
+
+  x <- drop_sp.("Poa spp.")
+  expect_identical(x, "Poa")
 })
 
 test_that("binomial_names", {


### PR DESCRIPTION
This PR closes #120 

``` r
# remotes::install_github("mattiaghilardi/taxadb", ref = "remove-spp")
taxadb::clean_names(c("Homo sp.", "Homo sp", "Homo sp1", "Homo sps", "Homo spp.", "Homo spp"))
#> [1] "homo" "homo" "homo" "homo" "homo" "homo"
```

<sup>Created on 2024-04-12 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
